### PR TITLE
Modified oracle_lib.py to capture object name if prefixed by schema name.

### DIFF
--- a/RunSQL.sql
+++ b/RunSQL.sql
@@ -1,6 +1,7 @@
 SET LINESIZE 2000
 SET PAGESIZE 0
 SET VERIFY OFF
+SET FEEDBACK OFF
 @&1
 SELECT 'Filename: &1' FROM DUAL;
 SELECT '(' || TYPE || ' ' || NAME || '/0:' || POSITION || ')' || ' ' || LINE || ':' || POSITION || ' ' || TEXT as ERRORS

--- a/oracle_lib.py
+++ b/oracle_lib.py
@@ -6,7 +6,7 @@ def find_entities(view):
     Return all 'create or replace' type and name in the script.
     """
     results = []
-    positions = view.find_all(r'(?im)create\s+(?:or\s+replace\s+)?(?:force\s+)?(package(?:\s+body)?|procedure|function|trigger|view)\s+(\w+)', 0, "$1 $2", results)
+    positions = view.find_all(r'(?im)create\s+(?:or\s+replace\s+)?(?:force\s+)?(package(?:\s+body)?|procedure|function|trigger|view|type)\s+(\w+\.)?(\w+)', 0, "$1 $3", results)
     return dict((val.upper(), view.rowcol(pos.begin())[0]) for (pos, val) in zip(positions, results))
 
 

--- a/readme.rst
+++ b/readme.rst
@@ -6,10 +6,14 @@ Language definition and execution utilities for Oracle PL/SQL files.
 
 It is based on the bundle http://code.google.com/p/oracle-textmate-bundle/ 
 
+Install
+-----
+Download and extract package. Rename folder from *Oracle-master* to *OracleSQL* and place in C:\\Users\\...\\AppData\\Roaming\\Sublime Text 2\\Packages\\
+
 Build
 -----
 
-To execute your PL/SQL source on your schema with ST2 Build command, you have to create a .sublime-build in your ST2 user folder file containing something like::
+To execute your PL/SQL source on your schema with ST2 Build command, you have to create a .sublime-build in your ST2 Users folder file containing something like::
 
     {
         "target": "oracle_exec",


### PR DESCRIPTION
I noticed that my Oracle build was not showing compilation errors in the buffer. This was because I prefix all of my objects with the schema name (team requirements), and the regex in oracle_lib.py was only capturing the schema, not the object name. I added a fourth capturing group and passed that to RunSQL. Also added `set feedback off` in RunSQL to suppress the `no rows selected` message when there were no errors, and added a bit to the documentation.

Nice plugin!
