### PR TITLE
oracle_exec.py - bug with empty sqlfilter

### DIFF
--- a/oracle_exec.py
+++ b/oracle_exec.py
@@ -20,11 +20,11 @@ class OracleExecCommand(execmod.ExecCommand):
                 sqlfilter = "\"''\""
             else:
                 sqlfilter = '"' + ",".join("'%s'" % entity for entity in self.entities.keys()) + '"'
-            
-            cmd = ["sqlplus.exe", "-s", dsn, "@", os.path.join(sublime.packages_path(), 'OracleSQL', 'RunSQL.sql'),
-                    self.window.active_view().file_name(), sqlfilter]
 
-            super(OracleExecCommand, self).run(cmd, "^Filename: (.+)$", "^\\(.+?/([0-9]+):([0-9]+)\\) [0-9]+:[0-9]+ (.+)$", **kwargs)
+            (directory, filename) = os.path.split(self.window.active_view().file_name())
+            cmd = ["sqlplus.exe", "-s", dsn, "@", os.path.join(sublime.packages_path(), 'OracleSQL', 'RunSQL.sql'), '"'+filename+'"', sqlfilter]
+
+            super(OracleExecCommand, self).run(cmd, "^Filename: (.+)$", "^\\(.+?/([0-9]+):([0-9]+)\\) [0-9]+:[0-9]+ (.+)$", working_dir=directory, **kwargs)
 
     def append_data(self, proc, data):
         # Update the line number of output_view with the correct line number of source view

--- a/oracle_exec.py
+++ b/oracle_exec.py
@@ -16,8 +16,11 @@ class OracleExecCommand(execmod.ExecCommand):
             # Find entities declaration in source
             self.entities = oracle_lib.find_entities(self.window.active_view())
             # Create a string for the in of sql command
-            sqlfilter = '"' + ",".join("'%s'" % entity for entity in self.entities.keys()) + '"'
-
+            if len(self.entities) == 0:
+                sqlfilter = "\"''\""
+            else:
+                sqlfilter = '"' + ",".join("'%s'" % entity for entity in self.entities.keys()) + '"'
+            
             cmd = ["sqlplus.exe", "-s", dsn, "@", os.path.join(sublime.packages_path(), 'OracleSQL', 'RunSQL.sql'),
                     self.window.active_view().file_name(), sqlfilter]
 


### PR DESCRIPTION
Occurs when there are no create/replace statements in the sql file being executed (oracle_lib.find_entities returns an empty dict).  The second parameter being sent to RunSQL.sql is empty and the USER_ERRORS select statement fails with an error, even though the sql file was executed successfully (which can be confusing to the user).  This fix simple sends an empty string as the second parameter in the case when no entities are returned by oracle_lib.
