### PR TITLE
Better schema prefix support

### DIFF
--- a/RunSQL.sql
+++ b/RunSQL.sql
@@ -4,7 +4,7 @@ SET VERIFY OFF
 SET FEEDBACK OFF
 @&1
 SELECT 'Filename: &1' FROM DUAL;
-SELECT '(' || TYPE || ' ' || NAME || '/' || LINE || ':' || POSITION || ')' || ' ' || LINE || ':' || POSITION || ' ' || TEXT as ERRORS
+SELECT '(' || TYPE || ' ' || NAME || '/0:' || POSITION || ')' || ' ' || LINE || ':' || POSITION || ' ' || TEXT as ERRORS
   FROM ALL_ERRORS
  WHERE line <> 0
    AND (

--- a/RunSQL.sql
+++ b/RunSQL.sql
@@ -4,9 +4,13 @@ SET VERIFY OFF
 SET FEEDBACK OFF
 @&1
 SELECT 'Filename: &1' FROM DUAL;
-SELECT '(' || TYPE || ' ' || NAME || '/0:' || POSITION || ')' || ' ' || LINE || ':' || POSITION || ' ' || TEXT as ERRORS
-  FROM USER_ERRORS
+SELECT '(' || TYPE || ' ' || NAME || '/' || LINE || ':' || POSITION || ')' || ' ' || LINE || ':' || POSITION || ' ' || TEXT as ERRORS
+  FROM ALL_ERRORS
  WHERE line <> 0
-   AND TYPE || ' ' || NAME in (&2)
+   AND (
+      TYPE || ' ' || OWNER || '.' || NAME in (&2)
+      OR
+      (OWNER = USER AND TYPE || ' ' || NAME in (&2))
+    )
 ORDER BY NAME, TYPE, SEQUENCE;
 exit

--- a/oracle_lib.py
+++ b/oracle_lib.py
@@ -6,7 +6,7 @@ def find_entities(view):
     Return all 'create or replace' type and name in the script.
     """
     results = []
-    positions = view.find_all(r'(?im)create\s+(?:or\s+replace\s+)?(?:force\s+)?(package(?:\s+body)?|procedure|function|trigger|view|type)\s+(\w+\.)?(\w+)', 0, "$1 $3", results)
+    positions = view.find_all(r'(?im)create\s+(?:or\s+replace\s+)?(?:force\s+)?(package(?:\s+body)?|procedure|function|trigger|view|type)\s+(\w+\.)?(\w+)', 0, "$1 $2$3", results)
     return dict((val.upper(), view.rowcol(pos.begin())[0]) for (pos, val) in zip(positions, results))
 
 


### PR DESCRIPTION
Schema prefixes are now retained through the process so that you can connect to the database as one user and compile a package for another user.

For example connect as fred/password@.../xe and compile the package mary.my_package correctly on the mary schema.

Querying of errors has been updated to reflect this also.
